### PR TITLE
Use correct delay in hard reset sequence

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ where
     where
         DELAY: DelayMs<u8>,
     {
-        self.hard_reset()?;
+        self.hard_reset(delay)?;
         self.write_command(Instruction::SWRESET, None)?;
         delay.delay_ms(200);
         self.write_command(Instruction::SLPOUT, None)?;
@@ -120,9 +120,14 @@ where
         Ok(())
     }
 
-    pub fn hard_reset(&mut self) -> Result<(), ()> {
+    pub fn hard_reset<DELAY>(&mut self, delay: &mut DELAY) -> Result<(), ()>
+    where
+        DELAY: DelayMs<u8>,
+    {
         self.rst.set_high().map_err(|_| ())?;
+        delay.delay_ms(10);
         self.rst.set_low().map_err(|_| ())?;
+        delay.delay_ms(10);
         self.rst.set_high().map_err(|_| ())
     }
 


### PR DESCRIPTION
The device I'm testing with (an adafruit 1.8" tft LCD) didn't work properly unless power cycled. This looks to be caused by the reset signal being too short. https://www.displayfuture.com/Display/datasheet/controller/ST7735.pdf This datasheet says that the reset should be at least 10 milliseconds.

Also, I'm not sure if setting the reset line `high` before `low` is  required.